### PR TITLE
Allow to disable resizing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ render() {
 | size | Size of dock panel (width or height, depending on `position`). If this prop is set, `Dock` is considered as a controlled component, so you need to use `onSizeChange` to track dock resizing. Value is a fraction of window width/height, if `fluid` is true, or pixels otherwise |
 | defaultSize | Default size of dock panel (used for uncontrolled `Dock` component) |
 | isVisible | If `true`, dock is visible |
+| isResizable | If `false`, then resizing is disabled |
 | dimMode | If `none` - content is not dimmed, if `transparent` - pointer events are disabled (so you can click through it), if `opaque` - click on dim area closes the dock. Default is `opaque` |
 | duration | Animation duration. Should be synced with transition animation in style properties |
 | dimStyle | Style for dim area |

--- a/lib/Dock.js
+++ b/lib/Dock.js
@@ -15,6 +15,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _lodash = require('lodash.debounce');
 
 var _lodash2 = _interopRequireDefault(_lodash);
@@ -468,20 +472,20 @@ var Dock = (_temp = _class = function (_Component) {
 
   return Dock;
 }(_react.Component), _class.propTypes = {
-  position: _react.PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
-  zIndex: _react.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.number]),
-  fluid: _react.PropTypes.bool,
-  size: _react.PropTypes.number,
-  defaultSize: _react.PropTypes.number,
-  dimMode: _react.PropTypes.oneOf(['none', 'transparent', 'opaque']),
-  isVisible: _react.PropTypes.bool,
-  onVisibleChange: _react.PropTypes.func,
-  onSizeChange: _react.PropTypes.func,
-  dimStyle: _react.PropTypes.object,
-  dockStyle: _react.PropTypes.object,
-  duration: _react.PropTypes.number,
-  outerContainerClassName: _react.PropTypes.string,
-  innerContainerClassName: _react.PropTypes.string
+  position: _propTypes2.default.oneOf(['left', 'right', 'top', 'bottom']),
+  zIndex: _propTypes2.default.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.number]),
+  fluid: _propTypes2.default.bool,
+  size: _propTypes2.default.number,
+  defaultSize: _propTypes2.default.number,
+  dimMode: _propTypes2.default.oneOf(['none', 'transparent', 'opaque']),
+  isVisible: _propTypes2.default.bool,
+  onVisibleChange: _propTypes2.default.func,
+  onSizeChange: _propTypes2.default.func,
+  dimStyle: _propTypes2.default.object,
+  dockStyle: _propTypes2.default.object,
+  duration: _propTypes2.default.number,
+  outerContainerClassName: _propTypes2.default.string,
+  innerContainerClassName: _propTypes2.default.string
 }, _class.defaultProps = {
   position: 'left',
   zIndex: 99999999,

--- a/src/Dock.js
+++ b/src/Dock.js
@@ -237,6 +237,7 @@ export default class Dock extends Component {
     defaultSize: PropTypes.number,
     dimMode: PropTypes.oneOf(['none', 'transparent', 'opaque']),
     isVisible: PropTypes.bool,
+    isResizable: PropTypes.bool,
     onVisibleChange: PropTypes.func,
     onSizeChange: PropTypes.func,
     dimStyle: PropTypes.object,
@@ -252,7 +253,8 @@ export default class Dock extends Component {
     fluid: true,
     defaultSize: 0.3,
     dimMode: 'opaque',
-    duration: 200
+    duration: 200,
+    isResizable: true
   }
 
   componentDidMount() {
@@ -322,7 +324,7 @@ export default class Dock extends Component {
   }
 
   render() {
-    const { children, zIndex, dimMode, position, isVisible } = this.props;
+    const { children, zIndex, dimMode, position, isVisible, isResizable } = this.props;
     const { isResizing, size, isDimHidden } = this.state;
 
     const dimStyles = Object.assign({}, ...getDimStyles(this.props, this.state));
@@ -345,8 +347,12 @@ export default class Dock extends Component {
           <div style={dimStyles} onClick={this.handleDimClick} />
         }
         <div className={innerClassNames} style={dockStyles}>
-          <div style={resizerStyles}
-               onMouseDown={this.handleMouseDown} />
+          {isResizable &&
+            <div
+              style={resizerStyles}
+              onMouseDown={this.handleMouseDown}
+            />
+          }
           <div style={styles.dockContent}>
             {typeof children === 'function' ?
               children({


### PR DESCRIPTION
Pass `isResizable` to control ability to resize the panel. (`true` by default for ensuring backwards compatability)